### PR TITLE
readme: update site link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PsyEnfantAdo | https://psyenfantado.beta.gouv.fr
+# PsyEnfantAdo | https://www.psyenfantado.sante.gouv.fr/
 CI branche `main` :  ![image](https://github.com/betagouv/psy-enfant-ado/workflows/Node.js%20CI/badge.svg)
 
 ## Lancer ce site localement
@@ -7,7 +7,7 @@ Vous devez avoir npm installé sur votre machine.
 ```bash
 git clone https://github.com/betagouv/psy-enfant-ado
 cd psy-enfant-ado
-cp npm install
+npm install
 npm run dev
 ```
 


### PR DESCRIPTION
Remplace https://psyenfantado.beta.gouv.fr/ par https://www.psyenfantado.sante.gouv.fr/ dasn le readme